### PR TITLE
Handle Subfields

### DIFF
--- a/encoding/none.go
+++ b/encoding/none.go
@@ -1,0 +1,13 @@
+package encoding
+
+var None Encoder = &noneEncoder{}
+
+type noneEncoder struct{}
+
+func (e *noneEncoder) Encode(data []byte) ([]byte, error) {
+	return data, nil
+}
+
+func (e *noneEncoder) Decode(data []byte, length int) ([]byte, int, error) {
+	return data, 0, nil
+}

--- a/field/bitmap_test.go
+++ b/field/bitmap_test.go
@@ -10,96 +10,88 @@ import (
 
 func TestHexBitmap(t *testing.T) {
 	t.Run("Read only first bitmap", func(t *testing.T) {
-		field := NewBitmap(&Spec{
+		bitmap := NewBitmap(&Spec{
 			Description: "Bitmap",
 			Enc:         encoding.Hex,
 			Pref:        prefix.Hex.Fixed,
 		})
 
 		// set bit: 10
-		read, err := field.Unpack([]byte("004000000000000000000000000000000000000000000000"))
+		read, err := bitmap.Unpack([]byte("004000000000000000000000000000000000000000000000"))
 
 		require.NoError(t, err)
 		require.Equal(t, 16, read) // 16 is 8 bytes (one bitmap) encoded in hex
-
-		bitmap := field.(*Bitmap)
 
 		require.True(t, bitmap.IsSet(10))
 	})
 
 	t.Run("Read two bitmaps", func(t *testing.T) {
-		field := NewBitmap(&Spec{
+		bitmap := NewBitmap(&Spec{
 			Description: "Bitmap",
 			Enc:         encoding.Hex,
 			Pref:        prefix.Hex.Fixed,
 		})
 
 		// set bits: 1, 10, 70
-		read, err := field.Unpack([]byte("804000000000000004000000000000000000000000000000"))
+		read, err := bitmap.Unpack([]byte("804000000000000004000000000000000000000000000000"))
 
 		require.NoError(t, err)
 		require.Equal(t, 32, read) // 32 is 16 bytes (two bitmaps) encoded in hex
-
-		bitmap := field.(*Bitmap)
 
 		require.True(t, bitmap.IsSet(10))
 		require.True(t, bitmap.IsSet(70))
 	})
 
 	t.Run("Read three bitmaps", func(t *testing.T) {
-		field := NewBitmap(&Spec{
+		bitmap := NewBitmap(&Spec{
 			Description: "Bitmap",
 			Enc:         encoding.Hex,
 			Pref:        prefix.Hex.Fixed,
 		})
 
 		// set bits: 1, 10, 65, 140
-		read, err := field.Unpack([]byte("804000000000000080000000000000000010000000000000"))
+		read, err := bitmap.Unpack([]byte("804000000000000080000000000000000010000000000000"))
 
 		require.NoError(t, err)
 		require.Equal(t, 48, read) // 48 is 24 bytes (three bitmaps) encoded in hex
-
-		bitmap := field.(*Bitmap)
 
 		require.True(t, bitmap.IsSet(10))
 		require.True(t, bitmap.IsSet(140))
 	})
 
 	t.Run("When not enough data to unpack", func(t *testing.T) {
-		field := NewBitmap(&Spec{
+		bitmap := NewBitmap(&Spec{
 			Description: "Bitmap",
 			Enc:         encoding.Hex,
 			Pref:        prefix.Hex.Fixed,
 		})
 
-		_, err := field.Unpack([]byte("4000"))
+		_, err := bitmap.Unpack([]byte("4000"))
 
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "for 1 bitmap: not enough data to read")
 	})
 
 	t.Run("When bit for secondary bitmap is set but not enough data to read", func(t *testing.T) {
-		field := NewBitmap(&Spec{
+		bitmap := NewBitmap(&Spec{
 			Description: "Bitmap",
 			Enc:         encoding.Hex,
 			Pref:        prefix.Hex.Fixed,
 		})
 
 		// bits 2, 20, 65, 120 are set, but no data for third bitmap
-		_, err := field.Unpack([]byte("c0001000000000008000000000000100"))
+		_, err := bitmap.Unpack([]byte("c0001000000000008000000000000100"))
 
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "for 3 bitmap: not enough data to read")
 	})
 
 	t.Run("With primary bitmap only it returns signle bitmap length", func(t *testing.T) {
-		field := NewBitmap(&Spec{
+		bitmap := NewBitmap(&Spec{
 			Description: "Bitmap",
 			Enc:         encoding.Hex,
 			Pref:        prefix.Hex.Fixed,
 		})
-
-		bitmap := field.(*Bitmap)
 
 		bitmap.Set(20) // first bitmap field
 
@@ -110,13 +102,11 @@ func TestHexBitmap(t *testing.T) {
 	})
 
 	t.Run("With secondary bitmap it returns length of two bitmaps", func(t *testing.T) {
-		field := NewBitmap(&Spec{
+		bitmap := NewBitmap(&Spec{
 			Description: "Bitmap",
 			Enc:         encoding.Hex,
 			Pref:        prefix.Hex.Fixed,
 		})
-
-		bitmap := field.(*Bitmap)
 
 		bitmap.Set(20) // first bitmap field
 		bitmap.Set(70) // second bitmap field
@@ -128,13 +118,11 @@ func TestHexBitmap(t *testing.T) {
 	})
 
 	t.Run("With third bitmap it returns length of three bitmaps", func(t *testing.T) {
-		field := NewBitmap(&Spec{
+		bitmap := NewBitmap(&Spec{
 			Description: "Bitmap",
 			Enc:         encoding.Hex,
 			Pref:        prefix.Hex.Fixed,
 		})
-
-		bitmap := field.(*Bitmap)
 
 		bitmap.Set(20)  // first bitmap field
 		bitmap.Set(70)  // second bitmap field
@@ -149,13 +137,11 @@ func TestHexBitmap(t *testing.T) {
 
 func TestBinaryBitmap(t *testing.T) {
 	t.Run("With primary bitmap only it returns signle bitmap length", func(t *testing.T) {
-		field := NewBitmap(&Spec{
+		bitmap := NewBitmap(&Spec{
 			Description: "Bitmap",
 			Enc:         encoding.Binary,
 			Pref:        prefix.Binary.Fixed,
 		})
-
-		bitmap := field.(*Bitmap)
 
 		bitmap.Set(20) // first bitmap field
 
@@ -166,13 +152,11 @@ func TestBinaryBitmap(t *testing.T) {
 	})
 
 	t.Run("With secondary bitmap it returns length of two bitmaps", func(t *testing.T) {
-		field := NewBitmap(&Spec{
+		bitmap := NewBitmap(&Spec{
 			Description: "Bitmap",
 			Enc:         encoding.Binary,
 			Pref:        prefix.Binary.Fixed,
 		})
-
-		bitmap := field.(*Bitmap)
 
 		bitmap.Set(20) // first bitmap field
 		bitmap.Set(70) // second bitmap field
@@ -184,13 +168,11 @@ func TestBinaryBitmap(t *testing.T) {
 	})
 
 	t.Run("With third bitmap it returns length of three bitmaps", func(t *testing.T) {
-		field := NewBitmap(&Spec{
+		bitmap := NewBitmap(&Spec{
 			Description: "Bitmap",
 			Enc:         encoding.Binary,
 			Pref:        prefix.Binary.Fixed,
 		})
-
-		bitmap := field.(*Bitmap)
 
 		bitmap.Set(20)  // first bitmap field
 		bitmap.Set(70)  // second bitmap field
@@ -200,5 +182,66 @@ func TestBinaryBitmap(t *testing.T) {
 
 		require.NoError(t, err)
 		require.Len(t, data, 24)
+	})
+}
+
+func TestBitmap_SetData(t *testing.T) {
+	spec := &Spec{
+		Description: "Bitmap",
+		Enc:         encoding.Hex,
+		Pref:        prefix.Hex.Fixed,
+	}
+	bitmapBytes := []byte("004000000000000000000000000000000000000000000000")
+
+	t.Run("Nil data causes no side effects", func(t *testing.T) {
+		bitmap := NewBitmap(spec)
+		err := bitmap.SetData(nil)
+		require.NoError(t, err)
+		require.Equal(t, NewBitmap(spec), bitmap)
+	})
+
+	t.Run("non-Bitmap data type returns error", func(t *testing.T) {
+		bitmap := NewBitmap(spec)
+
+		str := &struct {
+			a string
+		}{"left"}
+
+		err := bitmap.SetData(str)
+		require.Error(t, err)
+	})
+
+	t.Run("Unpack sets the data field with the correct bitmap provided using SetData", func(t *testing.T) {
+		bitmap := NewBitmap(spec)
+
+		data := &Bitmap{}
+		bitmap.SetData(data)
+		// set bit: 10
+		read, err := bitmap.Unpack(bitmapBytes)
+		require.NoError(t, err)
+		require.Equal(t, 16, read) // 16 is 8 bytes (one bitmap) encoded in hex
+
+		bitmapBytes, err := bitmap.Bytes()
+		require.NoError(t, err)
+		dataBytes, err := data.Bytes()
+		require.NoError(t, err)
+		require.Equal(t, bitmapBytes, dataBytes)
+	})
+
+	t.Run("Pack returns bytes using the bitmap provided using SetData", func(t *testing.T) {
+		bitmap := NewBitmap(spec)
+
+		data := &Bitmap{}
+		bitmap.SetData(data)
+		// set bit: 10
+		read, err := bitmap.Unpack(bitmapBytes)
+		require.NoError(t, err)
+		require.Equal(t, 16, read) // 16 is 8 bytes (one bitmap) encoded in hex
+
+		bitmapBytes, err := bitmap.Bytes()
+		require.NoError(t, err)
+		dataBytes, err := data.Bytes()
+		require.NoError(t, err)
+		require.Equal(t, bitmapBytes, dataBytes)
 	})
 }

--- a/field/field.go
+++ b/field/field.go
@@ -3,11 +3,14 @@ package field
 type Field interface {
 	Spec() *Spec
 	SetSpec(spec *Spec)
+
 	Pack() ([]byte, error)
 	Unpack(data []byte) (int, error)
 
-	SetBytes(b []byte)
-	Bytes() []byte
+	SetBytes(b []byte) error
+	Bytes() ([]byte, error)
 
-	String() string
+	SetData(d interface{}) error
+
+	String() (string, error)
 }

--- a/field/numeric.go
+++ b/field/numeric.go
@@ -11,9 +11,10 @@ var _ Field = (*Numeric)(nil)
 type Numeric struct {
 	Value int `json:"value"`
 	spec  *Spec
+	data  *Numeric
 }
 
-func NewNumeric(spec *Spec) Field {
+func NewNumeric(spec *Spec) *Numeric {
 	return &Numeric{
 		spec: spec,
 	}
@@ -33,16 +34,20 @@ func (f *Numeric) SetSpec(spec *Spec) {
 	f.spec = spec
 }
 
-func (f *Numeric) SetBytes(b []byte) {
-	f.Value, _ = strconv.Atoi(string(b))
+func (f *Numeric) SetBytes(b []byte) error {
+	val, err := strconv.Atoi(string(b))
+	if err == nil {
+		f.Value = val
+	}
+	return err
 }
 
-func (f *Numeric) Bytes() []byte {
-	return []byte(strconv.Itoa(f.Value))
+func (f *Numeric) Bytes() ([]byte, error) {
+	return []byte(strconv.Itoa(f.Value)), nil
 }
 
-func (f *Numeric) String() string {
-	return strconv.Itoa(f.Value)
+func (f *Numeric) String() (string, error) {
+	return strconv.Itoa(f.Value), nil
 }
 
 func (f *Numeric) Pack() ([]byte, error) {
@@ -87,7 +92,28 @@ func (f *Numeric) Unpack(data []byte) (int, error) {
 		return 0, fmt.Errorf("failed to convert into number: %v", err)
 	}
 
+	if f.data != nil {
+		*(f.data) = *f
+	}
+
 	return read + f.spec.Pref.Length(), nil
+}
+
+func (f *Numeric) SetData(data interface{}) error {
+	if data == nil {
+		return nil
+	}
+
+	num, ok := data.(*Numeric)
+	if !ok {
+		return fmt.Errorf("data does not match required *Numeric type")
+	}
+
+	f.data = num
+	if num.Value != 0 {
+		f.Value = num.Value
+	}
+	return nil
 }
 
 func (f *Numeric) MarshalJSON() ([]byte, error) {

--- a/field/numeric_test.go
+++ b/field/numeric_test.go
@@ -10,34 +10,49 @@ import (
 )
 
 func TestNumericField(t *testing.T) {
-	field := NewNumeric(&Spec{
+	spec := &Spec{
 		Length:      10,
 		Description: "Field",
 		Enc:         encoding.ASCII,
 		Pref:        prefix.ASCII.Fixed,
 		Pad:         padding.Left(' '),
-	})
+	}
+	numeric := NewNumeric(spec)
 
-	num := field.(*Numeric)
+	numeric.SetBytes([]byte("100"))
+	require.Equal(t, 100, numeric.Value)
 
-	field.SetBytes([]byte("100"))
-	require.Equal(t, 100, num.Value)
-
-	packed, err := field.Pack()
-
+	packed, err := numeric.Pack()
 	require.NoError(t, err)
 	require.Equal(t, "       100", string(packed))
 
-	length, err := field.Unpack([]byte("      9876"))
-
+	length, err := numeric.Unpack([]byte("      9876"))
 	require.NoError(t, err)
 	require.Equal(t, 10, length)
-	require.Equal(t, "9876", string(field.Bytes()))
-	require.Equal(t, 9876, num.Value)
+
+	b, err := numeric.Bytes()
+	require.NoError(t, err)
+	require.Equal(t, "9876", string(b))
+
+	require.Equal(t, 9876, numeric.Value)
+
+	numeric = NewNumeric(spec)
+	numeric.SetData(NewNumericValue(9876))
+	packed, err = numeric.Pack()
+	require.NoError(t, err)
+	require.Equal(t, "      9876", string(packed))
+
+	numeric = NewNumeric(spec)
+	data := NewNumericValue(0)
+	numeric.SetData(data)
+	length, err = numeric.Unpack([]byte("      9876"))
+	require.NoError(t, err)
+	require.Equal(t, 10, length)
+	require.Equal(t, 9876, data.Value)
 }
 
 func TestNumericFieldWithNotANumber(t *testing.T) {
-	field := NewNumeric(&Spec{
+	numeric := NewNumeric(&Spec{
 		Length:      10,
 		Description: "Field",
 		Enc:         encoding.ASCII,
@@ -45,17 +60,15 @@ func TestNumericFieldWithNotANumber(t *testing.T) {
 		Pad:         padding.Left(' '),
 	})
 
-	num := field.(*Numeric)
+	numeric.SetBytes([]byte("hello"))
+	require.Equal(t, 0, numeric.Value)
 
-	field.SetBytes([]byte("hello"))
-	require.Equal(t, 0, num.Value)
-
-	packed, err := field.Pack()
+	packed, err := numeric.Pack()
 
 	require.NoError(t, err)
 	require.Equal(t, "         0", string(packed))
 
-	_, err = field.Unpack([]byte("hhhhhhhhhh"))
+	_, err = numeric.Unpack([]byte("hhhhhhhhhh"))
 
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "failed to convert into number")

--- a/field/ordered_map.go
+++ b/field/ordered_map.go
@@ -1,0 +1,41 @@
+package field
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"sort"
+)
+
+// Custom type to sort keys in resulting JSON
+type OrderedMap map[int]Field
+
+func (om OrderedMap) MarshalJSON() ([]byte, error) {
+	keys := make([]int, 0, len(om))
+	for k := range om {
+		keys = append(keys, k)
+	}
+
+	sort.Ints(keys)
+
+	buf := &bytes.Buffer{}
+	buf.Write([]byte{'{'})
+	for _, i := range keys {
+		b, err := json.Marshal(om[i])
+		if err != nil {
+			return nil, err
+		}
+		buf.WriteString(fmt.Sprintf("\"%d\":", i))
+		buf.Write(b)
+
+		// don't add "," if it's the last item
+		if i == keys[len(keys)-1] {
+			break
+		}
+
+		buf.Write([]byte{','})
+	}
+	buf.Write([]byte{'}'})
+
+	return buf.Bytes(), nil
+}

--- a/field/string.go
+++ b/field/string.go
@@ -10,9 +10,10 @@ var _ Field = (*String)(nil)
 type String struct {
 	Value string `json:"value"`
 	spec  *Spec
+	data  *String
 }
 
-func NewString(spec *Spec) Field {
+func NewString(spec *Spec) *String {
 	return &String{
 		spec: spec,
 	}
@@ -32,16 +33,17 @@ func (f *String) SetSpec(spec *Spec) {
 	f.spec = spec
 }
 
-func (f *String) SetBytes(b []byte) {
+func (f *String) SetBytes(b []byte) error {
 	f.Value = string(b)
+	return nil
 }
 
-func (f *String) Bytes() []byte {
-	return []byte(f.Value)
+func (f *String) Bytes() ([]byte, error) {
+	return []byte(f.Value), nil
 }
 
-func (f *String) String() string {
-	return f.Value
+func (f *String) String() (string, error) {
+	return f.Value, nil
 }
 
 func (f *String) Pack() ([]byte, error) {
@@ -82,7 +84,28 @@ func (f *String) Unpack(data []byte) (int, error) {
 
 	f.Value = string(raw)
 
+	if f.data != nil {
+		*(f.data) = *f
+	}
+
 	return read + f.spec.Pref.Length(), nil
+}
+
+func (f *String) SetData(data interface{}) error {
+	if data == nil {
+		return nil
+	}
+
+	str, ok := data.(*String)
+	if !ok {
+		return fmt.Errorf("data does not match required *String type")
+	}
+
+	f.data = str
+	if str.Value != "" {
+		f.Value = str.Value
+	}
+	return nil
 }
 
 func (f *String) MarshalJSON() ([]byte, error) {

--- a/field/string_test.go
+++ b/field/string_test.go
@@ -10,28 +10,43 @@ import (
 )
 
 func TestStringField(t *testing.T) {
-	field := NewString(&Spec{
+	spec := &Spec{
 		Length:      10,
 		Description: "Field",
 		Enc:         encoding.ASCII,
 		Pref:        prefix.ASCII.Fixed,
 		Pad:         padding.Left(' '),
-	})
+	}
+	str := NewString(spec)
 
-	str := field.(*String)
-
-	field.SetBytes([]byte("hello"))
+	str.SetBytes([]byte("hello"))
 	require.Equal(t, "hello", str.Value)
 
-	packed, err := field.Pack()
-
+	packed, err := str.Pack()
 	require.NoError(t, err)
 	require.Equal(t, "     hello", string(packed))
 
-	length, err := field.Unpack([]byte("     olleh"))
-
+	length, err := str.Unpack([]byte("     olleh"))
 	require.NoError(t, err)
 	require.Equal(t, 10, length)
-	require.Equal(t, "olleh", string(field.Bytes()))
+
+	b, err := str.Bytes()
+	require.NoError(t, err)
+	require.Equal(t, "olleh", string(b))
+
 	require.Equal(t, "olleh", str.Value)
+
+	str = NewString(spec)
+	str.SetData(NewStringValue("hello"))
+	packed, err = str.Pack()
+	require.NoError(t, err)
+	require.Equal(t, "     hello", string(packed))
+
+	str = NewString(spec)
+	data := NewStringValue("")
+	str.SetData(data)
+	length, err = str.Unpack([]byte("     olleh"))
+	require.NoError(t, err)
+	require.Equal(t, 10, length)
+	require.Equal(t, "olleh", data.Value)
 }

--- a/field/subfields.go
+++ b/field/subfields.go
@@ -1,0 +1,222 @@
+package field
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"sort"
+
+	"github.com/moov-io/iso8583/encoding"
+	"github.com/moov-io/iso8583/padding"
+)
+
+var _ Field = (*Subfields)(nil)
+
+// Subfields is a wrapper object designed to hold ISO8583 subfields. It packs
+// and unpacks subfields ordered by ID. The following is not supported by
+// Subfields:
+//  - Padding
+//  - Encoding
+//
+// Responsibility for this is delegated recursively to the subfields
+// themselves.
+type Subfields struct {
+	spec *Spec
+
+	orderedFieldIDs []int
+	idToFieldMap    map[int]Field
+
+	data interface{}
+}
+
+// NewSubfields creates a new instance of the *Subfield struct,
+// validates and sets its Spec before returning it.
+// Refer to SetSpec() for more information on Spec validation.
+func NewSubfields(spec *Spec) *Subfields {
+	f := &Subfields{}
+	f.SetSpec(spec)
+	return f
+}
+
+// Spec returns the receiver's spec.
+func (f *Subfields) Spec() *Spec {
+	return f.spec
+}
+
+// SetSpec validates the spec and creates new instances of Fields defined
+// in the specification.
+// NOTE: Subfields do not support encoding and padding. Therefore, users should
+// only pass None or nil values for these types. Passing any other value will
+// result in a panic.
+func (f *Subfields) SetSpec(spec *Spec) {
+	if err := validateSubfieldsSpec(spec); err != nil {
+		panic(err)
+	}
+	f.spec = spec
+	f.idToFieldMap = spec.CreateMessageFields()
+	f.orderedFieldIDs = orderedKeys(f.idToFieldMap)
+}
+
+// SetData traverses through fields provided in the data parameter matches them
+// with their spec definition and calls SetData(...) on each spec field with the
+// appropriate data field.
+//
+// A valid input is as follows:
+//
+//		type SubfieldData struct {
+//			F1 *String
+//			F2 *String
+//			F3 *Numeric
+//		}
+//
+func (f *Subfields) SetData(data interface{}) error {
+	f.data = data
+
+	if f.data == nil {
+		return nil
+	}
+
+	dataStruct := reflect.ValueOf(data)
+	if dataStruct.Kind() == reflect.Ptr || dataStruct.Kind() == reflect.Interface {
+		// get the struct
+		dataStruct = dataStruct.Elem()
+	}
+
+	if dataStruct.Kind() != reflect.Struct {
+		return fmt.Errorf("failed to set data as struct is expected, got: %s", reflect.TypeOf(dataStruct).Kind())
+	}
+
+	for i, specField := range f.idToFieldMap {
+		fieldName := fmt.Sprintf("F%d", i)
+
+		// get the struct field
+		dataField := dataStruct.FieldByName(fieldName)
+
+		// no data field was found with this name
+		if dataField == (reflect.Value{}) {
+			continue
+		}
+
+		if dataField.IsNil() {
+			dataField.Set(reflect.New(dataField.Type().Elem()))
+		}
+		if err := specField.SetData(dataField.Interface()); err != nil {
+			return fmt.Errorf("failed to set data for field %d: %w", i, err)
+		}
+	}
+	return nil
+}
+
+// Pack deserialises data held by the receiver (via SetData)
+// into bytes and returns an error on failure.
+func (f *Subfields) Pack() ([]byte, error) {
+	packed := []byte{}
+	for _, id := range f.orderedFieldIDs {
+		packedBytes, err := f.idToFieldMap[id].Pack()
+		if err != nil {
+			return nil, fmt.Errorf("failed to pack subfield %d: %v", id, err)
+		}
+		packed = append(packed, packedBytes...)
+	}
+
+	packedLength, err := f.spec.Pref.EncodeLength(f.spec.Length, len(packed))
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode length: %v", err)
+	}
+
+	return append(packedLength, packed...), nil
+}
+
+// Unpack takes in a byte array and serialises them into the receiver's
+// subfields. An offset (unit depends on encoding and prefix values) is
+// returned on success. A non-nil error is returned on failure.
+func (f *Subfields) Unpack(data []byte) (int, error) {
+	dataLen, err := f.spec.Pref.DecodeLength(f.spec.Length, data)
+	if err != nil {
+		return 0, fmt.Errorf("failed to decode length: %v", err)
+	}
+
+	offset := f.spec.Pref.Length()
+	read, err := f.unpack(data[offset:])
+	if err != nil {
+		return 0, err
+	}
+	if dataLen != read {
+		return 0, fmt.Errorf("data length: %v does not match aggregate data read from decoded subfields: %v", dataLen, offset)
+	}
+
+	return read, nil
+}
+
+// SetBytes iterates over the receiver's subelements and unpacks them.
+// Data passed into this method must consist of the necessary information to
+// pack all subfields in full. However, unlike Unpack(), it requires the
+// aggregate length of the subfields not to be encoded in the prefix.
+func (f *Subfields) SetBytes(data []byte) error {
+	_, err := f.unpack(data)
+	return err
+}
+
+// Bytes iterates over the receiver's subelements and packs them. The result
+// does not incorporate the encoded aggregate length of the subfields in the
+// prefix.
+func (f *Subfields) Bytes() ([]byte, error) {
+	packed := []byte{}
+	for _, id := range f.orderedFieldIDs {
+		packedBytes, err := f.idToFieldMap[id].Pack()
+		if err != nil {
+			return nil, fmt.Errorf("failed to pack struct subfield: %v", err)
+		}
+		packed = append(packed, packedBytes...)
+	}
+	return packed, nil
+}
+
+// String iterates over the receiver's subelements, packs them and converts the
+// result to a string. The result does not incorporate the encoded aggregate
+// length of the subfields in the prefix.
+func (f *Subfields) String() (string, error) {
+	b, err := f.Bytes()
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+// MarshalJSON implements the encoding/json.Marshaler interface.
+func (f *Subfields) MarshalJSON() ([]byte, error) {
+	jsonData := OrderedMap(f.idToFieldMap)
+	return json.Marshal(jsonData)
+}
+
+func (f *Subfields) unpack(data []byte) (int, error) {
+	offset := 0
+	for _, id := range f.orderedFieldIDs {
+		fl := f.idToFieldMap[id]
+		read, err := fl.Unpack(data[offset:])
+		if err != nil {
+			return 0, fmt.Errorf("failed to unpack subfield %d: %v", id, err)
+		}
+		offset += read
+	}
+	return offset, nil
+}
+
+func validateSubfieldsSpec(spec *Spec) error {
+	if spec.Enc != nil && spec.Enc != encoding.None {
+		return fmt.Errorf("subfields spec only supports nil or None encoding values")
+	}
+	if spec.Pad != nil && spec.Pad != padding.None {
+		return fmt.Errorf("subfields spec only supports nil or None padding values")
+	}
+	return nil
+}
+
+func orderedKeys(kvs map[int]Field) []int {
+	keys := make([]int, 0)
+	for k, _ := range kvs {
+		keys = append(keys, k)
+	}
+	sort.Ints(keys)
+	return keys
+}

--- a/field/subfields_test.go
+++ b/field/subfields_test.go
@@ -1,0 +1,336 @@
+package field
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/moov-io/iso8583/encoding"
+	"github.com/moov-io/iso8583/padding"
+	"github.com/moov-io/iso8583/prefix"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	subfieldsTestSpec = &Spec{
+		Length:      6,
+		Description: "Test Spec",
+		Pref:        prefix.ASCII.Fixed,
+		Enc:         encoding.None,
+		Pad:         padding.None,
+		Fields: map[int]Field{
+			1: NewString(&Spec{
+				Length:      2,
+				Description: "String Field",
+				Enc:         encoding.ASCII,
+				Pref:        prefix.ASCII.Fixed,
+			}),
+			2: NewString(&Spec{
+				Length:      2,
+				Description: "String Field",
+				Enc:         encoding.ASCII,
+				Pref:        prefix.ASCII.Fixed,
+			}),
+			3: NewNumeric(&Spec{
+				Length:      2,
+				Description: "Numeric Field",
+				Enc:         encoding.ASCII,
+				Pref:        prefix.ASCII.Fixed,
+			}),
+		},
+	}
+)
+
+type SubfieldTestData struct {
+	F1 *String
+	F2 *String
+	F3 *Numeric
+}
+
+func TestSubfields_SetData(t *testing.T) {
+	t.Run("SetData returns an error on mismatch of subfield types", func(t *testing.T) {
+		type TestDataIncorrectType struct {
+			F1 *Numeric
+		}
+
+		subfields := NewSubfields(subfieldsTestSpec)
+		err := subfields.SetData(&TestDataIncorrectType{
+			F1: NewNumericValue(1),
+		})
+		require.Error(t, err)
+	})
+
+	t.Run("SetData returns an error on provision of primitive type data", func(t *testing.T) {
+		subfields := NewSubfields(subfieldsTestSpec)
+		err := subfields.SetData("primitive str")
+		require.Error(t, err)
+	})
+}
+
+func TestSubfieldsPacking(t *testing.T) {
+	t.Run("Pack returns error on failure of subfield packing", func(t *testing.T) {
+		data := &SubfieldTestData{
+			// This subfield will return an error on F1.Pack() as its length
+			// exceeds the max length defined in the spec.
+			F1: NewStringValue("ABCD"),
+			F2: NewStringValue("CD"),
+			F3: NewNumericValue(12),
+		}
+
+		subfields := NewSubfields(subfieldsTestSpec)
+		err := subfields.SetData(data)
+		require.NoError(t, err)
+
+		_, err = subfields.Pack()
+		require.Error(t, err)
+	})
+
+	t.Run("Pack returns error on failure to encode length", func(t *testing.T) {
+		invalidSpec := &Spec{
+			// Base field length < summation of lengths of subfields
+			// This will throw an error when encoding the field's length.
+			Length: 4,
+			Pref:   prefix.ASCII.Fixed,
+			Fields: map[int]Field{
+				1: NewString(&Spec{
+					Length: 2,
+					Enc:    encoding.ASCII,
+					Pref:   prefix.ASCII.Fixed,
+				}),
+				2: NewString(&Spec{
+					Length: 2,
+					Enc:    encoding.ASCII,
+					Pref:   prefix.ASCII.Fixed,
+				}),
+				3: NewNumeric(&Spec{
+					Length: 2,
+					Enc:    encoding.ASCII,
+					Pref:   prefix.ASCII.Fixed,
+				}),
+			},
+		}
+		data := &SubfieldTestData{
+			F1: NewStringValue("AB"),
+			F2: NewStringValue("CD"),
+			F3: NewNumericValue(12),
+		}
+
+		subfields := NewSubfields(invalidSpec)
+		err := subfields.SetData(data)
+		require.NoError(t, err)
+
+		_, err = subfields.Pack()
+		require.Error(t, err)
+	})
+
+	t.Run("Pack correctly serialises data to bytes", func(t *testing.T) {
+		data := &SubfieldTestData{
+			F1: NewStringValue("AB"),
+			F2: NewStringValue("CD"),
+			F3: NewNumericValue(12),
+		}
+
+		subfields := NewSubfields(subfieldsTestSpec)
+		err := subfields.SetData(data)
+		require.NoError(t, err)
+
+		packed, err := subfields.Pack()
+		require.NoError(t, err)
+
+		require.NoError(t, err)
+		require.Equal(t, "ABCD12", string(packed))
+	})
+
+	t.Run("Unpack returns an error on failure of subfield to unpack bytes", func(t *testing.T) {
+		data := &SubfieldTestData{}
+
+		subfields := NewSubfields(subfieldsTestSpec)
+		err := subfields.SetData(data)
+		require.NoError(t, err)
+
+		// Last two characters must be an integer type. F3 fails to unpack.
+		read, err := subfields.Unpack([]byte("ABCDEF"))
+		require.Equal(t, 0, read)
+		require.Error(t, err)
+	})
+
+	t.Run("Unpack returns an error on length of data exceeding max length", func(t *testing.T) {
+		spec := &Spec{
+			Length: 4,
+			Pref:   prefix.ASCII.L,
+			Fields: map[int]Field{
+				1: NewString(&Spec{
+					Length: 2,
+					Enc:    encoding.ASCII,
+					Pref:   prefix.ASCII.Fixed,
+				}),
+				2: NewString(&Spec{
+					Length: 2,
+					Enc:    encoding.ASCII,
+					Pref:   prefix.ASCII.Fixed,
+				}),
+				3: NewNumeric(&Spec{
+					Length: 2,
+					Enc:    encoding.ASCII,
+					Pref:   prefix.ASCII.Fixed,
+				}),
+			},
+		}
+		data := &SubfieldTestData{}
+
+		subfields := NewSubfields(spec)
+		err := subfields.SetData(data)
+		require.NoError(t, err)
+
+		// Length of denoted by prefix is too long, causing failure to decode length.
+		read, err := subfields.Unpack([]byte("7ABCD123"))
+		require.Equal(t, 0, read)
+		require.Error(t, err)
+	})
+
+	t.Run("Unpack returns an error on offset not matching data length", func(t *testing.T) {
+		invalidSpec := &Spec{
+			// Base field length < summation of lengths of subfields
+			// This will throw an error when encoding the field's length.
+			Length: 4,
+			Pref:   prefix.ASCII.Fixed,
+			Fields: map[int]Field{
+				1: NewString(&Spec{
+					Length: 2,
+					Enc:    encoding.ASCII,
+					Pref:   prefix.ASCII.Fixed,
+				}),
+				2: NewString(&Spec{
+					Length: 2,
+					Enc:    encoding.ASCII,
+					Pref:   prefix.ASCII.Fixed,
+				}),
+				3: NewNumeric(&Spec{
+					Length: 3,
+					Enc:    encoding.ASCII,
+					Pref:   prefix.ASCII.Fixed,
+				}),
+			},
+		}
+		data := &SubfieldTestData{}
+
+		subfields := NewSubfields(invalidSpec)
+		err := subfields.SetData(data)
+		require.NoError(t, err)
+
+		// Length of input too long, causing failure to decode length.
+		read, err := subfields.Unpack([]byte("ABCD123"))
+		require.Equal(t, 0, read)
+		require.Error(t, err)
+	})
+
+	t.Run("Unpack correctly deserialises bytes to the data struct", func(t *testing.T) {
+		data := &SubfieldTestData{}
+
+		subfields := NewSubfields(subfieldsTestSpec)
+		err := subfields.SetData(data)
+		require.NoError(t, err)
+
+		read, err := subfields.Unpack([]byte("ABCD12"))
+		require.Equal(t, subfieldsTestSpec.Length, read)
+		require.NoError(t, err)
+
+		require.Equal(t, "AB", data.F1.Value)
+		require.Equal(t, "CD", data.F2.Value)
+		require.Equal(t, 12, data.F3.Value)
+	})
+}
+
+func TestSubfieldsHandlesValidSpecs(t *testing.T) {
+	tests := []struct {
+		desc string
+		spec *Spec
+	}{
+		{
+			desc: "accepts nil Enc value",
+			spec: &Spec{
+				Length: 6,
+				Pref:   prefix.ASCII.Fixed,
+				Fields: map[int]Field{},
+			},
+		},
+		{
+			desc: "accepts None Enc value",
+			spec: &Spec{
+				Length: 6,
+				Pref:   prefix.ASCII.Fixed,
+				Enc:    encoding.None,
+				Fields: map[int]Field{},
+			},
+		},
+		{
+			desc: "accepts nil Pad value",
+			spec: &Spec{
+				Length: 6,
+				Pref:   prefix.ASCII.Fixed,
+				Fields: map[int]Field{},
+			},
+		},
+		{
+			desc: "accepts None Pad value",
+			spec: &Spec{
+				Length: 6,
+				Pref:   prefix.ASCII.Fixed,
+				Pad:    padding.None,
+				Fields: map[int]Field{},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(fmt.Sprintf("NewSubfields() %v", tc.desc), func(t *testing.T) {
+			f := NewSubfields(tc.spec)
+			require.Equal(t, tc.spec, f.Spec())
+		})
+		t.Run(fmt.Sprintf("Subfields.SetSpec() %v", tc.desc), func(t *testing.T) {
+			f := &Subfields{}
+			f.SetSpec(tc.spec)
+			require.Equal(t, tc.spec, f.Spec())
+		})
+	}
+}
+
+func TestSubfieldsPanicsOnSpecValidationFailures(t *testing.T) {
+	tests := []struct {
+		desc string
+		spec *Spec
+	}{
+		{
+			desc: "panics on non-None / non-nil Enc value being defined in spec",
+			spec: &Spec{
+				Length: 6,
+				Pref:   prefix.ASCII.Fixed,
+				Enc:    encoding.ASCII,
+				Pad:    padding.Left('0'),
+				Fields: map[int]Field{},
+			},
+		},
+		{
+			desc: "panics on non-None / non-nil Pad value being defined in spec",
+			spec: &Spec{
+				Length: 6,
+				Pref:   prefix.ASCII.Fixed,
+				Enc:    encoding.ASCII,
+				Pad:    padding.Left('0'),
+				Fields: map[int]Field{},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(fmt.Sprintf("NewSubfields() %v", tc.desc), func(t *testing.T) {
+			require.Panics(t, func() {
+				NewSubfields(tc.spec)
+			})
+		})
+		t.Run(fmt.Sprintf("Subfields.SetSpec() %v", tc.desc), func(t *testing.T) {
+			require.Panics(t, func() {
+				(&Subfields{}).SetSpec(tc.spec)
+			})
+		})
+	}
+}

--- a/message_test.go
+++ b/message_test.go
@@ -32,12 +32,30 @@ func TestMessage(t *testing.T) {
 				Enc:         encoding.ASCII,
 				Pref:        prefix.ASCII.LL,
 			}),
-			3: field.NewNumeric(&field.Spec{
+			3: field.NewSubfields(&field.Spec{
 				Length:      6,
 				Description: "Processing Code",
-				Enc:         encoding.ASCII,
 				Pref:        prefix.ASCII.Fixed,
-				Pad:         padding.Left('0'),
+				Fields: map[int]field.Field{
+					1: field.NewString(&field.Spec{
+						Length:      2,
+						Description: "Transaction Type",
+						Enc:         encoding.ASCII,
+						Pref:        prefix.ASCII.Fixed,
+					}),
+					2: field.NewString(&field.Spec{
+						Length:      2,
+						Description: "From Account",
+						Enc:         encoding.ASCII,
+						Pref:        prefix.ASCII.Fixed,
+					}),
+					3: field.NewString(&field.Spec{
+						Length:      2,
+						Description: "To Account",
+						Enc:         encoding.ASCII,
+						Pref:        prefix.ASCII.Fixed,
+					}),
+				},
 			}),
 			4: field.NewString(&field.Spec{
 				Length:      12,
@@ -52,9 +70,9 @@ func TestMessage(t *testing.T) {
 	t.Run("Test packing and unpacking untyped fields", func(t *testing.T) {
 		message := NewMessage(spec)
 		message.MTI("0100")
-		message.Field(2, "4242424242424242")
-		message.Field(3, "123456")
-		message.Field(4, "100")
+		require.NoError(t, message.Field(2, "4242424242424242"))
+		require.NoError(t, message.Field(3, "123456"))
+		require.NoError(t, message.Field(4, "100"))
 
 		got, err := message.Pack()
 
@@ -66,16 +84,33 @@ func TestMessage(t *testing.T) {
 		message = NewMessage(spec)
 		message.Unpack([]byte(want))
 
-		require.Equal(t, "0100", message.GetMTI())
-		require.Equal(t, "4242424242424242", message.GetString(2))
-		require.Equal(t, "123456", message.GetString(3))
-		require.Equal(t, "100", message.GetString(4))
+		s, err := message.GetMTI()
+		require.NoError(t, err)
+		require.Equal(t, "0100", s)
+
+		s, err = message.GetString(2)
+		require.NoError(t, err)
+		require.Equal(t, "4242424242424242", s)
+
+		s, err = message.GetString(3)
+		require.NoError(t, err)
+		require.Equal(t, "123456", s)
+
+		s, err = message.GetString(4)
+		require.NoError(t, err)
+		require.Equal(t, "100", s)
 	})
 
 	t.Run("Test unpacking with typed fields", func(t *testing.T) {
+		type TestISOF3Data struct {
+			F1 *field.String
+			F2 *field.String
+			F3 *field.String
+		}
+
 		type ISO87Data struct {
 			F2 *field.String
-			F3 *field.Numeric
+			F3 *TestISOF3Data
 			F4 *field.String
 		}
 
@@ -87,21 +122,37 @@ func TestMessage(t *testing.T) {
 
 		require.NoError(t, err)
 
-		require.Equal(t, "4242424242424242", message.GetString(2))
-		require.Equal(t, "123456", message.GetString(3))
-		require.Equal(t, "100", message.GetString(4))
+		s, err := message.GetString(2)
+		require.NoError(t, err)
+		require.Equal(t, "4242424242424242", s)
+
+		s, err = message.GetString(3)
+		require.NoError(t, err)
+		require.Equal(t, "123456", s)
+
+		s, err = message.GetString(4)
+		require.NoError(t, err)
+		require.Equal(t, "100", s)
 
 		data := message.Data().(*ISO87Data)
 
 		require.Equal(t, "4242424242424242", data.F2.Value)
-		require.Equal(t, 123456, data.F3.Value)
+		require.Equal(t, "12", data.F3.F1.Value)
+		require.Equal(t, "34", data.F3.F2.Value)
+		require.Equal(t, "56", data.F3.F3.Value)
 		require.Equal(t, "100", data.F4.Value)
 	})
 
 	t.Run("Test packing with typed fields", func(t *testing.T) {
+		type TestISOF3Data struct {
+			F1 *field.String
+			F2 *field.String
+			F3 *field.String
+		}
+
 		type ISO87Data struct {
 			F2 *field.String
-			F3 *field.Numeric
+			F3 *TestISOF3Data
 			F4 *field.String
 		}
 
@@ -109,13 +160,16 @@ func TestMessage(t *testing.T) {
 		message.MTI("0100")
 		err := message.SetData(&ISO87Data{
 			F2: field.NewStringValue("4242424242424242"),
-			F3: field.NewNumericValue(123456),
+			F3: &TestISOF3Data{
+				F1: field.NewStringValue("12"),
+				F2: field.NewStringValue("34"),
+				F3: field.NewStringValue("56"),
+			},
 			F4: field.NewStringValue("100"),
 		})
 		require.NoError(t, err)
 
 		rawMsg, err := message.Pack()
-
 		require.NoError(t, err)
 
 		wantMsg := []byte("01007000000000000000164242424242424242123456000000000100")
@@ -143,11 +197,30 @@ func TestPackUnpack(t *testing.T) {
 				Enc:         encoding.ASCII,
 				Pref:        prefix.ASCII.LL,
 			}),
-			3: field.NewString(&field.Spec{
+			3: field.NewSubfields(&field.Spec{
 				Length:      6,
 				Description: "Processing Code",
-				Enc:         encoding.ASCII,
 				Pref:        prefix.ASCII.Fixed,
+				Fields: map[int]field.Field{
+					1: field.NewString(&field.Spec{
+						Length:      2,
+						Description: "Transaction Type",
+						Enc:         encoding.ASCII,
+						Pref:        prefix.ASCII.Fixed,
+					}),
+					2: field.NewString(&field.Spec{
+						Length:      2,
+						Description: "From Account",
+						Enc:         encoding.ASCII,
+						Pref:        prefix.ASCII.Fixed,
+					}),
+					3: field.NewString(&field.Spec{
+						Length:      2,
+						Description: "To Account",
+						Enc:         encoding.ASCII,
+						Pref:        prefix.ASCII.Fixed,
+					}),
+				},
 			}),
 			4: field.NewNumeric(&field.Spec{
 				Length:      12,
@@ -283,9 +356,15 @@ func TestPackUnpack(t *testing.T) {
 		},
 	}
 
+	type TestISOF3Data struct {
+		F1 *field.String
+		F2 *field.String
+		F3 *field.String
+	}
+
 	type TestISOData struct {
 		F2   *field.String
-		F3   *field.String
+		F3   *TestISOF3Data
 		F4   *field.Numeric
 		F7   *field.Numeric
 		F11  *field.Numeric
@@ -311,8 +390,12 @@ func TestPackUnpack(t *testing.T) {
 	t.Run("Pack data", func(t *testing.T) {
 		message := NewMessage(spec)
 		message.SetData(&TestISOData{
-			F2:   field.NewStringValue("4276555555555555"),
-			F3:   field.NewStringValue("000000"),
+			F2: field.NewStringValue("4276555555555555"),
+			F3: &TestISOF3Data{
+				F1: field.NewStringValue("00"),
+				F2: field.NewStringValue("00"),
+				F3: field.NewStringValue("00"),
+			},
 			F4:   field.NewNumericValue(77700),
 			F7:   field.NewNumericValue(701111844),
 			F11:  field.NewNumericValue(123),
@@ -354,14 +437,24 @@ func TestPackUnpack(t *testing.T) {
 
 		require.NoError(t, err)
 
-		require.Equal(t, "4276555555555555", message.GetString(2))
-		require.Equal(t, "000000", message.GetString(3))
-		require.Equal(t, "77700", message.GetString(4))
+		s, err := message.GetString(2)
+		require.NoError(t, err)
+		require.Equal(t, "4276555555555555", s)
+
+		s, err = message.GetString(3)
+		require.NoError(t, err)
+		require.Equal(t, "000000", s)
+
+		s, err = message.GetString(4)
+		require.NoError(t, err)
+		require.Equal(t, "77700", s)
 
 		data := message.Data().(*TestISOData)
 
 		assert.Equal(t, "4276555555555555", data.F2.Value)
-		assert.Equal(t, "000000", data.F3.Value)
+		assert.Equal(t, "00", data.F3.F1.Value)
+		assert.Equal(t, "00", data.F3.F2.Value)
+		assert.Equal(t, "00", data.F3.F3.Value)
 		assert.Equal(t, 77700, data.F4.Value)
 		assert.Equal(t, 701111844, data.F7.Value)
 		assert.Equal(t, 123, data.F11.Value)
@@ -404,12 +497,30 @@ func TestMessageJSON(t *testing.T) {
 				Enc:         encoding.ASCII,
 				Pref:        prefix.ASCII.LL,
 			}),
-			3: field.NewNumeric(&field.Spec{
+			3: field.NewSubfields(&field.Spec{
 				Length:      6,
 				Description: "Processing Code",
-				Enc:         encoding.ASCII,
 				Pref:        prefix.ASCII.Fixed,
-				Pad:         padding.Left('0'),
+				Fields: map[int]field.Field{
+					1: field.NewString(&field.Spec{
+						Length:      2,
+						Description: "Transaction Type",
+						Enc:         encoding.ASCII,
+						Pref:        prefix.ASCII.Fixed,
+					}),
+					2: field.NewString(&field.Spec{
+						Length:      2,
+						Description: "From Account",
+						Enc:         encoding.ASCII,
+						Pref:        prefix.ASCII.Fixed,
+					}),
+					3: field.NewString(&field.Spec{
+						Length:      2,
+						Description: "To Account",
+						Enc:         encoding.ASCII,
+						Pref:        prefix.ASCII.Fixed,
+					}),
+				},
 			}),
 			4: field.NewString(&field.Spec{
 				Length:      12,
@@ -421,14 +532,33 @@ func TestMessageJSON(t *testing.T) {
 		},
 	}
 
+	type TestISOF3Data struct {
+		F1 *field.String
+		F2 *field.String
+		F3 *field.String
+	}
+
+	type TestISOData struct {
+		F2 *field.String
+		F3 *TestISOF3Data
+		F4 *field.String
+	}
+
 	t.Run("Test JSON encoding", func(t *testing.T) {
 		message := NewMessage(spec)
 		message.MTI("0100")
-		message.Field(2, "4242424242424242")
-		message.Field(3, "123456")
-		message.Field(4, "100")
+		err := message.SetData(&TestISOData{
+			F2: field.NewStringValue("4242424242424242"),
+			F3: &TestISOF3Data{
+				F1: field.NewStringValue("12"),
+				F2: field.NewStringValue("34"),
+				F3: field.NewStringValue("56"),
+			},
+			F4: field.NewStringValue("100"),
+		})
+		require.NoError(t, err)
 
-		want := `{"0":"0100","1":"700000000000000000000000000000000000000000000000","2":"4242424242424242","3":123456,"4":"100"}`
+		want := `{"0":"0100","1":"700000000000000000000000000000000000000000000000","2":"4242424242424242","3":{"1":"12","2":"34","3":"56"},"4":"100"}`
 
 		got, err := json.Marshal(message)
 		require.NoError(t, err)


### PR DESCRIPTION
This pull request is the first of a few to add support to this library for complex fields (fields with structured information within them). More specifically, it adds behaviour to set, pack and unpack ISO8583 subfields.

Unfortunately, this pull request is more involved than I would've ideally liked and also includes breaking changes for users of the library. 

## New Behaviour

As a consequence of this PR, users may now set, get, pack and unpack ISO8583 `Subfields` as shown below.

Firstly, users may defined `Subfields` within a `MessageSpec` as such:

```
    spec := &MessageSpec{
        Fields: map[int]field.Field{
            ...
            3: field.NewSubfields(&field.Spec{
                Length:      6,
                Description: "Processing Code",
                Pref:        prefix.ASCII.Fixed,
                Fields: map[int]field.Field{
                    1: field.NewString(&field.Spec{
                        Length:      2,
                        Description: "Transaction Type",
                        Enc:         encoding.ASCII,
                        Pref:        prefix.ASCII.Fixed,
                    }),
                    2: field.NewString(&field.Spec{
                        Length:      2,
                        Description: "From Account",
                        Enc:         encoding.ASCII,
                        Pref:        prefix.ASCII.Fixed,
                    }),
                    3: field.NewString(&field.Spec{
                        Length:      2,
                        Description: "To Account",
                        Enc:         encoding.ASCII,
                        Pref:        prefix.ASCII.Fixed,
                    }),
                },
            }),
            ...
        },
    }
```

Using the untyped API, subfields may be set and packed in a consistent manner with all other field types:

```
    err := message.Field(3, "123456")
    if err != nil {
        fmt.Errorf("...")
    }
    bytes, err := message.Pack()
```


Furthermore, subfields may also be retrieved using the untyped API in a consistent manner with all other field types:

```
    // s == "123456"
    s, err = message.GetString(3)
```

Using the typed API, `Subfields` data may be defined as such:

```
    type TestISOF3Data struct {
        F1 *field.String
        F2 *field.String
        F3 *field.String
    }

    type ISO87Data struct {
        ...
        F3 *TestISOF3Data
        ...
    }
```

And packed:    
```
    message := NewMessage(spec)		
    message.MTI("0100")		
    err := message.SetData(&ISO87Data{	
        ...
        F3: &TestISOF3Data{
	      F1: field.NewStringValue("12"),
	      F2: field.NewStringValue("34"),	
	      F3: field.NewStringValue("56"),	
        },	
    })
    rawMsg, err := message.Pack()
```

They may be unpacked and retrieved in a typed manner as such:

```
    message.SetData(&ISO87Data{})
    
    err := message.Unpack([]byte(...))
    if err != nil {
        ...
    }
    data := message.Data().(*ISO87Data)

    f1 := data.F3.F1.Value // "12"
    f2 := data.F3.F2.Value // "34"
    f3 := data.F3.F3.Value // "56"
```

JSON representation of subfields is as follows:

```
{
   "0":"0100",
   "1":"700000000000000000000000000000000000000000000000",
   "2":"4242424242424242",
   // Before this would have been a flat field as such: "3": "123456".
   // This structure mirrors that of the message spec but does vary away from 
   // just having flat fields. We can discuss with upstream if this is really the 
   // behaviour we want.
   "3": {
       "1": "12",
       "2": "34",
       "3": "56",
     }
   "4":"100"
}
```


## Changes Made 

We have amended the `field.Field` interface as such:

Old:
```
type Field interface {    
    Spec() *Spec    
    SetSpec(spec *Spec)    
    
    Pack() ([]byte, error)    
    Unpack(data []byte) (int, error)    
    
    SetBytes(b []byte)    
    Bytes() []byte    
    
    String() string
}
```

New:
```
type Field interface {    
    Spec() *Spec    
    SetSpec(spec *Spec)    

    Pack() ([]byte, error)    
    Unpack(data []byte) (int, error)
    
    SetBytes(b []byte) error    
    Bytes() ([]byte, error)    
    
    SetData(d interface{}) error    

    String() (string, error)
}
```

`SetData(...)` behaves in a similar fashion to `Message.SetData`. It leverages reflection to traverse through fields provided in the `data` arg and sets their `Spec` with the correct value. For scalar types such as `String` and `Numeric`, `SetData` simply involves storing a reference to the `data` field provided along with its `Value` (if it has been set). When `Unpack` is called (using an empty `data` field), these types then populate the deserialised value of said field into the `data` struct provided. When `Pack` is called using a populated `data` field (provided using `SetData`), its provided value is serialised into bytes. 

The eagle eyed of the audience will also note that `error` has been added to the return types of `SetBytes(...)`, `Bytes()` and `String()`. This is because our implementation of `Subfields` leverages `Unpack` and `Pack` respectively in order to set and get bytes to and from the underlying fields. More information on this can be found in the respective method documentation. Unfortunately, this results in a breaking change for users on previous versions of the library - an alternative would be to panic or drop the error, both of would lead to unexpected client observable behaviour.

To allow for fields to be nested within other fields, we also enhance the `field.Spec` struct to hold additional information. Namely:

```
type Spec struct {                                                                                                                                                          
    Length      int                                                                                                                                                             
    Description string                                                                                                                                                         
    Enc         encoding.Encoder                                                                                                                                               
    Pref        prefix.Prefixer                                                                                                                                                
    Pad         padding.Padder   
    // This may be changed to `map[string]Field` in the future to accommodate for TLVs.                                                                                                                                           
+   Fields      map[int]Field                                     
}  
```

The `Fields` field is leveraged to set `Spec`s within nested subfields or generate empty defaults if the untyped API is used. Due to nuances in the implementation of `Subelements` and `TLVs`, it's possible that we may have to change the type of `Fields` from `map[int]Field` to `map[string]Field`. I held back from making such a change in this PR to prevent premature optimisation, however it does mean more breaking changes could be made soon.

Finally, we have updated all of the constructors in the `field` package to return a pointer to their concrete types rather than the `field.Field` interface. This change is inspired by the '[Accept Interfaces Return Struct](https://mycodesmells.com/post/accept-interfaces-return-struct-in-go)' Golang principle. Interfaces are implemented implicitly in Go and this means that a type can implement multiple interfaces at once, without me doing anything except defining methods the type should use.

## Next Steps

Since we have laid down most of the boilerplate required to set, get, pack and unpack complex fields, our next steps are to raise pull requests for `Subelements` and eventually `TLVs`. 

TLVs hold alphanumeric/binary IDs (called tags) instead of the standard integer IDs leveraged by data elements, subfields and subelements. As described above, this may require that we make further breaking changes to the `Spec` struct once again. Following on from that, these PRs should be much more straightforward to implement given nothing unexpected arises along the way 🤞.